### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/DomainTestService.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/DomainTestService.java
@@ -22,8 +22,8 @@ public class DomainTestService {
     }
 
     try {
-      //TODO use ProcessBuilder which looks cleaner
-      Process process = Runtime.getRuntime().exec(new String[] {"sh", "-c", "ping -c 1 " + domainName});
+      ProcessBuilder processBuilder = new ProcessBuilder("ping", "-c", "1", domainName);
+      Process process = processBuilder.start();
       if (!process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)) {
         throw new UnableToTestDomainException("Timed out pinging domain");
       }


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_1/security/code-scanning/1](https://github.com/Brook-5686/Java_1/security/code-scanning/1)

To fix the problem, we should avoid directly concatenating user input into the command string. Instead, we can use `ProcessBuilder` to safely construct the command with arguments. `ProcessBuilder` allows us to pass the command and its arguments as separate elements, which helps prevent command injection.

**Steps to fix:**
1. Replace the `Runtime.getRuntime().exec` call with `ProcessBuilder`.
2. Pass the domain name as a separate argument to the `ping` command.
3. Ensure that the domain name is properly validated and sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
