### PR TITLE
Fix code scanning alert no. 3: Cross-site scripting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.apache.commons:commons-text:1.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
@@ -1,4 +1,5 @@
 package com.datadoghq.workshops.samplevulnerablejavaapp.controller;
+import org.apache.commons.text.StringEscapeUtils;
 
 import com.datadoghq.workshops.samplevulnerablejavaapp.exception.FileForbiddenFileException;
 import com.datadoghq.workshops.samplevulnerablejavaapp.exception.FileReadException;
@@ -58,7 +59,8 @@ public class MainController {
     log.info("Reading file " + request.path);
     try {
       String result = fileService.readFile(request.path);
-      return new ResponseEntity<>(result, HttpStatus.OK);
+      String escapedResult = StringEscapeUtils.escapeHtml4(result);
+      return new ResponseEntity<>(escapedResult, HttpStatus.OK);
     } catch (FileForbiddenFileException e) {
       return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
     } catch (FileReadException e) {


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_1/security/code-scanning/3](https://github.com/Brook-5686/Java_1/security/code-scanning/3)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided input is properly sanitized or encoded before being included in the response. In this case, we can use a library like Apache Commons Text to escape HTML characters in the `result` string before returning it in the response entity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
