### PR TITLE
Fix code scanning alert no. 2: Cross-site scripting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.apache.commons:commons-text:1.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.apache.commons.text.StringEscapeUtils;
 
 @RestController
 public class MainController {
@@ -50,7 +51,8 @@ public class MainController {
   public ResponseEntity<String> testWebsite(@RequestBody WebsiteTestRequest request) {
     log.info("Testing website " + request.url);
     String result = websiteTestService.testWebsite(request);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    String escapedResult = org.apache.commons.text.StringEscapeUtils.escapeHtml4(result);
+    return new ResponseEntity<>(escapedResult, HttpStatus.OK);
   }
 
   @RequestMapping(method=RequestMethod.POST, value="/view-file", consumes="application/json")


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_1/security/code-scanning/2](https://github.com/Brook-5686/Java_1/security/code-scanning/2)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data included in the HTTP response is properly sanitized or encoded. In this case, we should encode the `result` before including it in the response to prevent any malicious scripts from being executed.

The best way to fix this issue is to use a library like `org.apache.commons.text.StringEscapeUtils` to escape HTML content. This will ensure that any potentially dangerous characters in the `result` are properly encoded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
